### PR TITLE
Add platform amd64 to docker compose so a not amd64 can emulate it 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: docker-compose
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   chef-workstation:
     image: ubuntu:20.04
+    platform: linux/amd64
     stdin_open: true
     ports:
       - "8000:8000"


### PR DESCRIPTION
I was doing the course at https://pec.progress.com/course/2552175/module/6023860/Scorm but it did not run because I am using a ARM laptop. By merging this fix you can run it on AMD64 and ARM64 without any changes.